### PR TITLE
Add ability to set handshake timeout (#149)

### DIFF
--- a/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/GrizzlyLDAPConnection.java
+++ b/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/GrizzlyLDAPConnection.java
@@ -19,6 +19,7 @@ package org.forgerock.opendj.grizzly;
 import static com.forgerock.opendj.grizzly.GrizzlyMessages.LDAP_CONNECTION_BIND_OR_START_TLS_CONNECTION_TIMEOUT;
 import static com.forgerock.opendj.grizzly.GrizzlyMessages.LDAP_CONNECTION_BIND_OR_START_TLS_REQUEST_TIMEOUT;
 import static com.forgerock.opendj.grizzly.GrizzlyMessages.LDAP_CONNECTION_REQUEST_TIMEOUT;
+import static org.forgerock.opendj.grizzly.GrizzlyUtils.getLongProperty;
 import static org.forgerock.opendj.ldap.LDAPConnectionFactory.REQUEST_TIMEOUT;
 import static org.forgerock.opendj.ldap.LdapException.newLdapException;
 import static org.forgerock.opendj.ldap.ResultCode.CLIENT_SIDE_LOCAL_ERROR;
@@ -823,6 +824,7 @@ final class GrizzlyLDAPConnection implements LDAPConnectionImpl, TimeoutEventLis
                     .toArray(new String[cipherSuites.size()]));
             sslEngineConfigurator.setCipherConfigured(true);
             final SSLFilter sslFilter = new SSLFilter(DUMMY_SSL_ENGINE_CONFIGURATOR, sslEngineConfigurator);
+            sslFilter.setHandshakeTimeout(getLongProperty("org.forgerock.opendj.grizzly.handshakeTimeout", sslFilter.getHandshakeTimeout(TimeUnit.MILLISECONDS)), TimeUnit.MILLISECONDS);
             installFilter(sslFilter);
             sslFilter.handshake(connection, completionHandler);
         }

--- a/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/GrizzlyUtils.java
+++ b/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/GrizzlyUtils.java
@@ -225,6 +225,15 @@ final class GrizzlyUtils {
         }
     }
 
+    static long getLongProperty(final String name, final long defaultValue) {
+        final String value = System.getProperty(name);
+        try {
+            return value != null ? Long.parseLong(value) : defaultValue;
+        } catch (final NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
     /** Prevent instantiation. */
     private GrizzlyUtils() {
         // No implementation required.

--- a/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/LDAPServerFilter.java
+++ b/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/LDAPServerFilter.java
@@ -18,6 +18,7 @@ package org.forgerock.opendj.grizzly;
 
 import static com.forgerock.reactive.RxJavaStreams.*;
 import static org.forgerock.opendj.grizzly.GrizzlyUtils.configureConnection;
+import static org.forgerock.opendj.grizzly.GrizzlyUtils.getLongProperty;
 import static org.forgerock.opendj.io.LDAP.*;
 import static org.forgerock.opendj.ldap.responses.Responses.newGenericExtendedResult;
 import static org.forgerock.opendj.ldap.spi.LdapMessages.newResponseMessage;
@@ -28,6 +29,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.net.ssl.SSLEngine;
@@ -384,7 +386,9 @@ public final class LDAPServerFilter extends BaseFilter {
                     return false;
                 }
                 SSLUtils.setSSLEngine(connection, sslEngine);
-                installFilter(startTls ? new StartTLSFilter(new SSLFilter()) : new SSLFilter());
+                SSLFilter sslFilter = new SSLFilter();
+                sslFilter.setHandshakeTimeout(getLongProperty("org.forgerock.opendj.grizzly.handshakeTimeout", sslFilter.getHandshakeTimeout(TimeUnit.MILLISECONDS)), TimeUnit.MILLISECONDS);
+                installFilter(startTls ? new StartTLSFilter(sslFilter) : sslFilter);
                 return true;
             }
         }


### PR DESCRIPTION
This patch adds the ability to set the TLS handshake timeout
of Grizzly connections through java property
"org.forgerock.opendj.grizzly.handshakeTimeout". If not set
the value from Grizzlys SSLBaseFilter will be used, default -1.

Change-Id: I546207e834a31a91549191ba9fc3cc420d953fb4

Co-authored-by: Niclas Tillman <niclas.tillman@ericsson.com>